### PR TITLE
Available themes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
   - "1.12.x"
+cache:
+  directories:
+    - $GOPATH/pkg/mod
 env:
   global:
     - GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Colorized cat command.
 $ go get github.com/toshimaru/nyan
 ```
 
+## Usage
+
+```
+$ nyan FILE
+```
+
 ## What is nyan?
 
 `nyan` originated from [nyan-cat](http://www.nyan.cat/).

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -29,7 +30,8 @@ var isTerminalFunc = isatty.IsTerminal
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, `show version`)
-	rootCmd.PersistentFlags().StringVarP(&theme, "theme", "t", "monokai", "color theme")
+	rootCmd.PersistentFlags().StringVarP(&theme, "theme", "t", "monokai", fmt.Sprintf(`color theme
+available themes: %s`, styles.Names()))
 }
 
 func main() {


### PR DESCRIPTION
resolves #18 

```console
$ go run main.go -h
Colorized cat

Usage:
  nyan [FILE] [flags]

Examples:
$ nyan FILE

Flags:
  -h, --help           help for nyan
  -t, --theme string   color theme
                       available themes: [dracula monokai solarized-dark swapoff vim] (default "monokai")
  -v, --version        show version
```