### PR TITLE
Better Standard Error Output using PrintErr

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 	} else {
 		for _, filename := range args {
 			if data, err = ioutil.ReadFile(filename); err != nil {
-				cmd.Println(err)
+				cmd.PrintErrln(err)
 				continue
 			}
 			if language != "" {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func init() {
 func main() {
 	rootCmd.SetOutput(colorable.NewColorableStdout())
 	if err := rootCmd.Execute(); err != nil {
-		rootCmd.SetOutput(os.Stderr)
+		rootCmd.SetOutput(colorable.NewColorableStderr())
 		rootCmd.Println(err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -39,10 +39,11 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, `Show version`)
 	rootCmd.PersistentFlags().StringVarP(&theme, "theme", "t", "monokai", fmt.Sprintf("Set color theme for syntax highlighting\nAvailable themes: %s", styles.Names()))
 	rootCmd.PersistentFlags().StringVarP(&language, "language", "l", "", "Specify language for syntax highlighting")
+
+	rootCmd.SetOutput(colorable.NewColorableStdout())
 }
 
 func main() {
-	rootCmd.SetOutput(colorable.NewColorableStdout())
 	if err := rootCmd.Execute(); err != nil {
 		rootCmd.SetOutput(colorable.NewColorableStderr())
 		rootCmd.Println(err)

--- a/main.go
+++ b/main.go
@@ -40,7 +40,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&theme, "theme", "t", "monokai", fmt.Sprintf("Set color theme for syntax highlighting\nAvailable themes: %s", styles.Names()))
 	rootCmd.PersistentFlags().StringVarP(&language, "language", "l", "", "Specify language for syntax highlighting")
 
-	rootCmd.SetOutput(colorable.NewColorableStdout())
+	rootCmd.SetOut(colorable.NewColorableStdout())
+	rootCmd.SetErr(colorable.NewColorableStderr())
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -45,8 +45,7 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		rootCmd.SetOutput(colorable.NewColorableStderr())
-		rootCmd.Println(err)
+		rootCmd.PrintErrln(err)
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		rootCmd.PrintErrln(err)
+		// FIXME: use PrintErrln after upstream is fixed
+		rootCmd.PrintErr(err, "\n")
 		os.Exit(1)
 	}
 }
@@ -76,7 +77,8 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 	} else {
 		for _, filename := range args {
 			if data, err = ioutil.ReadFile(filename); err != nil {
-				cmd.PrintErrln(err)
+				// FIXME: use PrintErrln after upstream is fixed
+				cmd.PrintErr(err, "\n")
 				continue
 			}
 			if language != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -236,8 +236,8 @@ func TestFromStdInWithDash(t *testing.T) {
 func TestShell(t *testing.T) {
 	t.Run("echo+pipe", func(t *testing.T) {
 		cmd := exec.Command("bash", "-c", "echo pipetest | ./nyan")
-		o := new(bytes.Buffer)
-		cmd.Stdout = o
+		var o bytes.Buffer
+		cmd.Stdout = &o
 		err := cmd.Run()
 		assert.Nil(t, err)
 		assert.NotNil(t, o.String())

--- a/main_test.go
+++ b/main_test.go
@@ -28,9 +28,9 @@ func TestCommandExecute(t *testing.T) {
 }
 
 func TestHelpCommand(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	rootCmd.SetArgs([]string{"--help"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetFlags()
 
@@ -41,11 +41,10 @@ func TestHelpCommand(t *testing.T) {
 }
 
 func TestInvalidFilename(t *testing.T) {
-	o := bytes.NewBufferString("")
-	e := bytes.NewBufferString("")
+	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"InvalidFilename"})
-	rootCmd.SetOut(o)
-	rootCmd.SetOut(e)
+	rootCmd.SetOut(&o)
+	rootCmd.SetOut(&e)
 	err := rootCmd.Execute()
 
 	assert.NotNil(t, err)
@@ -55,10 +54,10 @@ func TestInvalidFilename(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -67,10 +66,10 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteWithAnalyseUnknownFile(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go.unknown"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -79,10 +78,10 @@ func TestExecuteWithAnalyseUnknownFile(t *testing.T) {
 }
 
 func TestLanguageOption(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--language", "go", "testdata/dummy.go.unknown"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetStrings()
 
@@ -92,10 +91,10 @@ func TestLanguageOption(t *testing.T) {
 }
 
 func TestInvlaidLanguageOption(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--language", "invalid_lang", "testdata/dummy.go"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetStrings()
 
@@ -105,10 +104,10 @@ func TestInvlaidLanguageOption(t *testing.T) {
 }
 
 func TestMultipleFiles(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "testdata/dummyfile"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -118,12 +117,11 @@ func TestMultipleFiles(t *testing.T) {
 }
 
 func TestMultipleFilesWithInvalidFileError(t *testing.T) {
-	o := bytes.NewBufferString("")
-	e := bytes.NewBufferString("")
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "InvalidFilename", "testdata/dummyfile"})
-	rootCmd.SetOut(o)
-	rootCmd.SetErr(e)
+	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -133,10 +131,10 @@ func TestMultipleFilesWithInvalidFileError(t *testing.T) {
 	assert.Contains(t, e.String(), invalidFileErrorMsg())
 }
 func TestInvalidTheme(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "--theme", "invalid"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetStrings()
 
@@ -146,10 +144,10 @@ func TestInvalidTheme(t *testing.T) {
 }
 
 func TestValidTheme(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "--theme", "vim"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetStrings()
 
@@ -159,9 +157,9 @@ func TestValidTheme(t *testing.T) {
 }
 
 func TestVersionFlag(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	rootCmd.SetArgs([]string{"-v"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetFlags()
 
@@ -171,9 +169,9 @@ func TestVersionFlag(t *testing.T) {
 }
 
 func TestListThemesFlag(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	rootCmd.SetArgs([]string{"--list-themes"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 	resetFlags()
 
@@ -184,9 +182,9 @@ func TestListThemesFlag(t *testing.T) {
 }
 
 func TestUnknownFile(t *testing.T) {
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	rootCmd.SetArgs([]string{"testdata/dummyfile"})
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -196,11 +194,11 @@ func TestUnknownFile(t *testing.T) {
 
 func TestFromStdIn(t *testing.T) {
 	i := bytes.NewBufferString("package main")
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--theme", "monokai"})
 	rootCmd.SetIn(i)
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -210,11 +208,11 @@ func TestFromStdIn(t *testing.T) {
 
 func TestFromStdInWithLanguageOption(t *testing.T) {
 	i := bytes.NewBufferString("package main")
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--theme", "monokai", "--language", "go"})
 	rootCmd.SetIn(i)
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -224,10 +222,10 @@ func TestFromStdInWithLanguageOption(t *testing.T) {
 
 func TestFromStdInWithDash(t *testing.T) {
 	i := bytes.NewBufferString("TestFromStdIn")
-	o := bytes.NewBufferString("")
+	var o bytes.Buffer
 	rootCmd.SetArgs([]string{"-"})
 	rootCmd.SetIn(i)
-	rootCmd.SetOut(o)
+	rootCmd.SetOut(&o)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
@@ -238,8 +236,8 @@ func TestFromStdInWithDash(t *testing.T) {
 func TestShell(t *testing.T) {
 	t.Run("echo+pipe", func(t *testing.T) {
 		cmd := exec.Command("bash", "-c", "echo pipetest | ./nyan")
-		var o bytes.Buffer
-		cmd.Stdout = &o
+		o := new(bytes.Buffer)
+		cmd.Stdout = o
 		err := cmd.Run()
 		assert.Nil(t, err)
 		assert.NotNil(t, o.String())

--- a/main_test.go
+++ b/main_test.go
@@ -42,13 +42,16 @@ func TestHelpCommand(t *testing.T) {
 
 func TestInvalidFilename(t *testing.T) {
 	o := bytes.NewBufferString("")
+	e := bytes.NewBufferString("")
 	rootCmd.SetArgs([]string{"InvalidFilename"})
 	rootCmd.SetOut(o)
+	rootCmd.SetOut(e)
 	err := rootCmd.Execute()
 
 	assert.NotNil(t, err)
 	assert.NotNil(t, o.String())
-	assert.Contains(t, o.String(), invalidFileErrorMsg())
+	assert.Contains(t, o.String(), "")
+	assert.Contains(t, e.String(), invalidFileErrorMsg())
 }
 
 func TestExecute(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -175,6 +175,7 @@ func TestListThemesFlag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "Theme: ")
+	assert.Contains(t, o.String(), "Sample Code in Go")
 }
 
 func TestUnknownFile(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -28,13 +28,15 @@ func TestCommandExecute(t *testing.T) {
 }
 
 func TestHelpCommand(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"--help"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetFlags()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.Contains(t, o.String(), rootCmd.Use)
 	assert.Contains(t, o.String(), rootCmd.Long)
 	assert.Contains(t, o.String(), rootCmd.Example)
@@ -44,7 +46,7 @@ func TestInvalidFilename(t *testing.T) {
 	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"InvalidFilename"})
 	rootCmd.SetOut(&o)
-	rootCmd.SetOut(&e)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.NotNil(t, err)
@@ -54,63 +56,73 @@ func TestInvalidFilename(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
 }
 
 func TestExecuteWithAnalyseUnknownFile(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go.unknown"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), _unhighlightedGoCode())
 }
 
 func TestLanguageOption(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--language", "go", "testdata/dummy.go.unknown"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetStrings()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
 }
 
 func TestInvlaidLanguageOption(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--language", "invalid_lang", "testdata/dummy.go"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetStrings()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), _unhighlightedGoCode())
 }
 
 func TestMultipleFiles(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "testdata/dummyfile"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
 	assert.Contains(t, o.String(), "[0m[38;5;231mThis is dummy.[0m")
@@ -131,104 +143,120 @@ func TestMultipleFilesWithInvalidFileError(t *testing.T) {
 	assert.Contains(t, e.String(), invalidFileErrorMsg())
 }
 func TestInvalidTheme(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "--theme", "invalid"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetStrings()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "[1m[38;5;231mpackage")
 }
 
 func TestValidTheme(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "--theme", "vim"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetStrings()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "[38;5;164mpackage[0m")
 }
 
 func TestVersionFlag(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"-v"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetFlags()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "version ")
 }
 
 func TestListThemesFlag(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"--list-themes"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 	resetFlags()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "Theme: ")
 	assert.Contains(t, o.String(), "Sample Code in Go")
 }
 
 func TestUnknownFile(t *testing.T) {
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"testdata/dummyfile"})
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "This is dummy.")
 }
 
 func TestFromStdIn(t *testing.T) {
 	i := bytes.NewBufferString("package main")
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--theme", "monokai"})
 	rootCmd.SetIn(i)
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
 }
 
 func TestFromStdInWithLanguageOption(t *testing.T) {
 	i := bytes.NewBufferString("package main")
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"--theme", "monokai", "--language", "go"})
 	rootCmd.SetIn(i)
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
 }
 
 func TestFromStdInWithDash(t *testing.T) {
 	i := bytes.NewBufferString("TestFromStdIn")
-	var o bytes.Buffer
+	var o, e bytes.Buffer
 	rootCmd.SetArgs([]string{"-"})
 	rootCmd.SetIn(i)
 	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
+	assert.Empty(t, e.String())
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "TestFromStdIn")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -116,16 +116,18 @@ func TestMultipleFiles(t *testing.T) {
 
 func TestMultipleFilesWithInvalidFileError(t *testing.T) {
 	o := bytes.NewBufferString("")
+	e := bytes.NewBufferString("")
 	isTerminalFunc = func(fd uintptr) bool { return true }
 	rootCmd.SetArgs([]string{"testdata/dummy.go", "InvalidFilename", "testdata/dummyfile"})
 	rootCmd.SetOut(o)
+	rootCmd.SetErr(e)
 	err := rootCmd.Execute()
 
 	assert.Nil(t, err)
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
-	assert.Contains(t, o.String(), invalidFileErrorMsg())
 	assert.Contains(t, o.String(), "[38;5;231mThis is dummy.[0m")
+	assert.Contains(t, e.String(), invalidFileErrorMsg())
 }
 func TestInvalidTheme(t *testing.T) {
 	o := bytes.NewBufferString("")


### PR DESCRIPTION
## Changes

- Set Stdout and Stderr on init func
- Use `PrintErr` instead of `Print`
  - TODO: fix upstream `PrintErrln`
- Use `var` statement instead of `NewBufferString`