### PR TITLE
Better error output and exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,10 +77,12 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 		}
 		printData(&data, cmd, lexer)
 	} else {
+		var lastErr error
 		for _, filename := range args {
 			if data, err = ioutil.ReadFile(filename); err != nil {
 				// FIXME: use PrintErrln after upstream is fixed
 				cmd.PrintErr(err, "\n")
+				lastErr = err
 				continue
 			}
 			if language != "" {
@@ -90,8 +92,11 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 			}
 			printData(&data, cmd, lexer)
 		}
+		if lastErr != nil {
+			cmd.SilenceUsage = true
+			return lastErr
+		}
 	}
-
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 
 	if len(args) < 1 || args[0] == "-" {
 		if data, err = ioutil.ReadAll(cmd.InOrStdin()); err != nil {
-			cmd.PrintErr(err, "\n")
+			cmd.PrintErr("Error: ", err, "\n")
 			return
 		}
 		if language != "" {
@@ -80,7 +80,7 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 		for _, filename := range args {
 			if data, err = ioutil.ReadFile(filename); err != nil {
 				// FIXME: use PrintErrln after upstream is fixed
-				cmd.PrintErr(err, "\n")
+				cmd.PrintErr("Error: ", err, "\n")
 				lastErr = err
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -48,8 +48,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		// FIXME: use PrintErrln after upstream is fixed
-		rootCmd.PrintErr(err, "\n")
 		os.Exit(1)
 	}
 }
@@ -68,6 +66,7 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 
 	if len(args) < 1 || args[0] == "-" {
 		if data, err = ioutil.ReadAll(cmd.InOrStdin()); err != nil {
+			cmd.PrintErr(err, "\n")
 			return
 		}
 		if language != "" {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,9 @@ var rootCmd = &cobra.Command{
 	Example: `$ nyan FILE
 $ nyan FILE1 FILE2 FILE3
 $ nyan -t solarized-dark FILE`,
-	RunE: cmdMain,
+	RunE:          cmdMain,
+	SilenceErrors: true,
+	SilenceUsage:  false,
 }
 
 func init() {

--- a/main_test.go
+++ b/main_test.go
@@ -49,7 +49,7 @@ func TestInvalidFilename(t *testing.T) {
 	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), "")
 	assert.Contains(t, e.String(), invalidFileErrorMsg())
@@ -136,7 +136,7 @@ func TestMultipleFilesWithInvalidFileError(t *testing.T) {
 	rootCmd.SetErr(&e)
 	err := rootCmd.Execute()
 
-	assert.Nil(t, err)
+	assert.Error(t, err)
 	assert.NotNil(t, o.String())
 	assert.Contains(t, o.String(), highlightedGoCode)
 	assert.Contains(t, o.String(), "[38;5;231mThis is dummy.[0m")

--- a/main_test.go
+++ b/main_test.go
@@ -325,9 +325,9 @@ func resetStrings() {
 
 func invalidFileErrorMsg() string {
 	if runtime.GOOS == "windows" {
-		return "open InvalidFilename: The system cannot find the file specified."
+		return "Error: open InvalidFilename: The system cannot find the file specified."
 	}
-	return "open InvalidFilename: no such file or directory"
+	return "Error: open InvalidFilename: no such file or directory"
 }
 
 func _unhighlightedGoCode() string {

--- a/main_test.go
+++ b/main_test.go
@@ -50,8 +50,7 @@ func TestInvalidFilename(t *testing.T) {
 	err := rootCmd.Execute()
 
 	assert.Error(t, err)
-	assert.NotNil(t, o.String())
-	assert.Contains(t, o.String(), "")
+	assert.Empty(t, o.String())
 	assert.Contains(t, e.String(), invalidFileErrorMsg())
 }
 


### PR DESCRIPTION
closes #57

## Before 

```console
$ nyan x go.mod
open x: no such file or directory
module github.com/toshimaru/nyan

go 1.13

require (
	github.com/alecthomas/chroma v0.6.8
	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
	github.com/dlclark/regexp2 v1.1.8 // indirect
	github.com/mattn/go-colorable v0.1.4
	github.com/mattn/go-isatty v0.0.10
	github.com/spf13/cobra v0.0.5
	github.com/stretchr/testify v1.3.0
)

$ echo $?
0
```

```console
$ nyan x
open x: no such file or directory
Error: open x: no such file or directory
Usage:
  nyan [OPTION]... [FILE]... [flags]

Examples:
   ...
```

## After

```console
$  go run main.go -- x go.mod
Error: open x: no such file or directory
module github.com/toshimaru/nyan

go 1.13

require (
	github.com/alecthomas/chroma v0.6.8
	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
	github.com/dlclark/regexp2 v1.1.8 // indirect
	github.com/mattn/go-colorable v0.1.4
	github.com/mattn/go-isatty v0.0.10
	github.com/spf13/cobra v0.0.5
	github.com/stretchr/testify v1.3.0
)
exit status 1

$ echo $?
1
```

```console
$ go run main.go -- x
Error: open x: no such file or directory
exit status 1
```