### PR TITLE
Bump Go version from 1.14 to 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.14.0'
+        go-version: '^1.15.0'
     - run: go mod download
     - name: Build & Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,5 @@ jobs:
       uses: goreleaser/goreleaser-action@master
       with:
         args: release --snapshot --skip-publish --rm-dist
-    # GitHub Actions doesn't support colored output, so comment it out temporarily.
-    # - name: Colored Output Test
-    #   run: go run main.go -- main.go
+    - name: Colored Output Test
+      run: go run main.go -- main.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,6 @@ jobs:
       uses: goreleaser/goreleaser-action@master
       with:
         args: release --snapshot --skip-publish --rm-dist
-    - name: Colored Output Test
-      run: go run main.go -- main.go
+    # GitHub Actions doesn't support colored output, so comment it out temporarily.
+    # - name: Colored Output Test
+    #   run: go run main.go -- main.go

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,4 +14,4 @@ jobs:
         CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b
       with:
         coverageCommand: go test ./... -coverprofile c.out
-        # prefix: github.com/toshimaru/nyan
+        prefix: github.com/toshimaru/nyan

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         go-version: '^1.15.0'
     - run: go mod download && go build
-    - uses: paambaati/codeclimate-action@v2.6.0
+    - uses: paambaati/codeclimate-action@v2.5.0
       env:
         CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         go-version: '^1.15.0'
     - run: go mod download && go build
-    - uses: paambaati/codeclimate-action@v2.5.0
+    - uses: paambaati/codeclimate-action@v2.6.0
       env:
         CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.14.0'
+        go-version: '^1.15.0'
     - run: go mod download && go build
     - uses: paambaati/codeclimate-action@v2.5.0
       env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,8 @@
 name: Coverage with CodeClimate
 on: [push]
 jobs:
-  build:
+  codeclimate-report:
     runs-on: ubuntu-latest
-    name: codeclimate-report
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -15,4 +14,4 @@ jobs:
         CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b
       with:
         coverageCommand: go test ./... -coverprofile c.out
-        prefix: github.com/toshimaru/nyan
+        # prefix: github.com/toshimaru/nyan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       run: git fetch --prune --unshallow
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.14.0'
+        go-version: '^1.15.0'
     - name: Release via goreleaser
       uses: goreleaser/goreleaser-action@master
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ on:
     tags:
       - v*.*.*
 jobs:
-  build:
+  goreleaser:
     runs-on: ubuntu-latest
-    name: goreleaser
     steps:
     - uses: actions/checkout@v2
     - name: Unshallow Fetch

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ changelog:
     - '^docs:'
     - '^test:'
 brews:
-- github:
+- tap:
     owner: toshimaru
     name: homebrew-nyan
   description: Colored cat command which supports syntax highlighting. 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ builds:
     - linux
     - darwin
     - windows
+  ignore:
+    - goos: darwin
+      goarch: 386
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
   replacements:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/toshimaru/nyan
 
-go 1.14
+go 1.15
 
 require (
 	github.com/alecthomas/chroma v0.8.0


### PR DESCRIPTION
1. Use Go v1.15.

2. Fix the following error.

```
⨯ release failed after 49.01s error=failed to build for darwin_386: cmd/go: unsupported GOOS/GOARCH pair darwin/386
```

3. Fix the deprecation message:

```
DEPRECATED: `brews.github` should not be used anymore, check https://goreleaser.com/deprecations#brewsgithub for more info.
```