### PR TITLE
Remove `go mod download`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,9 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16'
-    - run: go mod download
     - name: Build & Test
       run: |
-        go build -v .
+        go build -v
         go test ./...
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16'
-    - run: go mod download && go build
+    - run: go build
     - uses: paambaati/codeclimate-action@v2.7.5
       env:
         CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,3 @@
-before:
-  hooks:
-    - go mod download
-    # - go generate ./...
 builds:
 - env:
     - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ archives:
     386: i386
     amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: '{{ .ProjectName }}_checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
@@ -26,11 +26,13 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+    - Merge pull request
 brews:
 - tap:
     owner: toshimaru
     name: homebrew-nyan
   description: Colored cat command which supports syntax highlighting. 
   homepage: https://github.com/toshimaru/nyan
+  license: MIT
   test: |
     system "#{bin}/nyan -v"


### PR DESCRIPTION
Since go module is enabled by default.

> Module-aware mode is enabled by default, regardless of whether a go.mod file is present in the current working directory or a parent directory

[Go 1.16 Release Notes - The Go Programming Language](https://golang.org/doc/go1.16)