### PR TITLE
Fix goreleaser build error (Use `goreleaser check` instead)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,16 @@ jobs:
       run: |
         go build -v
         go test ./...
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@master
+    - name: goreleaser check
+      uses: goreleaser/goreleaser-action@v2
       with:
-        args: release --snapshot --skip-publish --rm-dist
+        args: check
+
+    # - name: goreleaser test
+    #   uses: goreleaser/goreleaser-action@v2
+    #   with:
+    #     args: check --snapshot --skip-publish --rm-dist
+
     # GitHub Actions doesn't support colored output, so comment it out temporarily.
     # - name: Colored Output Test
     #   run: go run main.go -- main.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
       with:
         args: check
 
-    # - name: goreleaser test
+    # cf. https://github.com/toshimaru/nyan/issues/119
+    # - name: Run GoReleaser
     #   uses: goreleaser/goreleaser-action@v2
     #   with:
-    #     args: check --snapshot --skip-publish --rm-dist
+    #     args: release --snapshot --skip-publish --rm-dist
 
     # GitHub Actions doesn't support colored output, so comment it out temporarily.
     # - name: Colored Output Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         go-version: '1.16'
     - name: Release via goreleaser
-      uses: goreleaser/goreleaser-action@master
+      uses: goreleaser/goreleaser-action@v2
       with:
         args: release
       env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,13 +11,16 @@ builds:
     - goos: windows
       goarch: arm64
 archives:
-- name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+    - goos: windows
+      format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ archives:
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,11 +33,11 @@ changelog:
     - '^test:'
     - Merge pull request
 brews:
-- tap:
-    owner: toshimaru
-    name: homebrew-nyan
-  description: Colored cat command which supports syntax highlighting. 
-  homepage: https://github.com/toshimaru/nyan
-  license: MIT
-  test: |
-    system "#{bin}/nyan -v"
+  - tap:
+      owner: toshimaru
+      name: homebrew-nyan
+    description: Colored cat command which supports syntax highlighting
+    homepage: https://github.com/toshimaru/nyan
+    license: MIT
+    test: |
+      system "#{bin}/nyan", "-v"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: 386
+    - goos: windows
+      goarch: arm64
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
   replacements:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ archives:
     386: i386
     amd64: x86_64
 checksum:
-  name_template: '{{ .ProjectName }}_checksums.txt'
+  name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:


### PR DESCRIPTION
- Fix brew error
  - See also. https://github.com/toshimaru/homebrew-nyan/pull/2
- Ignore windows x arm64
  - https://goreleaser.com/deprecations/#builds-for-windowsarm64

## CI Issue

- see. https://github.com/toshimaru/nyan/issues/119
