### PR TITLE
Use staticcheck instead of golint / Remove deprecated ioutil pkg

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,16 +9,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17'
-      - name: install tools
-        run: |
-          go get golang.org/x/lint/golint
+      - uses: reviewdog/action-staticcheck@v1
+        with:
+          fail_on_error: true
       - uses: reviewdog/action-setup@v1
       - name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          reviewdog -reporter=github-pr-review \
-                    -runners=golint,govet,gofmt \
-                    -fail-on-error
-      # reviewdog doesn't work with go vet, so run again
-      - run: go vet ./...
+          reviewdog -reporter=github-pr-review -runners=gofmt

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,11 +1,13 @@
 name: reviewdog
-on: [pull_request]
+on: [pull_request_target]
 jobs:
   reviewdog:
     name: reviewdog
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17'

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,8 +11,7 @@ jobs:
           go-version: '1.17'
       - name: install tools
         run: |
-          go get -u golang.org/x/lint/golint
-          go get github.com/mattn/go-isatty
+          go get golang.org/x/lint/golint
       - uses: reviewdog/action-setup@v1
       - name: Run reviewdog
         env:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,10 +69,12 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 		lexer = lexers.Get(language)
 	}
 
+	cmd.SilenceUsage = true
+
 	if len(args) < 1 || args[0] == "-" {
 		if data, err = io.ReadAll(cmd.InOrStdin()); err != nil {
 			cmd.PrintErrln("Error:", err)
-			return
+			return err
 		}
 		if lexer == nil {
 			lexer = lexers.Analyse(string(data))
@@ -92,7 +94,6 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 			printData(&data, cmd, lexer)
 		}
 		if lastErr != nil {
-			cmd.SilenceUsage = true
 			return lastErr
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/alecthomas/chroma"
@@ -71,7 +70,7 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if len(args) < 1 || args[0] == "-" {
-		if data, err = ioutil.ReadAll(cmd.InOrStdin()); err != nil {
+		if data, err = io.ReadAll(cmd.InOrStdin()); err != nil {
 			cmd.PrintErrln("Error:", err)
 			return
 		}
@@ -82,7 +81,7 @@ func cmdMain(cmd *cobra.Command, args []string) (err error) {
 	} else {
 		var lastErr error
 		for _, filename := range args {
-			if data, err = ioutil.ReadFile(filename); err != nil {
+			if data, err = os.ReadFile(filename); err != nil {
 				cmd.PrintErrln("Error:", err)
 				lastErr = err
 				continue

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -59,7 +59,7 @@ func TestShell(t *testing.T) {
 		outfile := "testdata/output"
 		cmd := exec.Command("bash", "-c", "echo 'package main' | ./nyan > "+outfile)
 		err := cmd.Run()
-		data, err := ioutil.ReadFile(outfile)
+		data, err := os.ReadFile(outfile)
 		assert.Nil(t, err)
 		assert.Equal(t, "package main\n", string(data))
 	})


### PR DESCRIPTION
- Use [staticcheck](https://staticcheck.io/) instead of [golint](https://github.com/golang/lint)
- Use `pull_request_target`
  - ref. [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests | GitHub Security Lab](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- return err when an error occurs
- ioutil → io
  - https://go.dev/doc/go1.16#ioutil