### PR TITLE
Colored output test by enabling TTY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       with:
         args: release --snapshot --skip-publish --rm-dist
 
-    # GitHub Actions doesn't support colored output, so comment it out temporarily.
-    # - name: Colored Output Test
-    #   run: go run main.go -- main.go
+    # ref. https://github.com/gfx/example-github-actions-with-tty
+    - name: Colored Output Test
+      if: runner.os == 'Linux'
+      shell: 'script -q -e -c "bash {0}"'
+      run: go run main.go -- main.go


### PR DESCRIPTION
## Description

Configure colored output test only if the OS is linux.

## Screenshot

<img width="422" alt="image" src="https://user-images.githubusercontent.com/803398/162608472-a411ac96-4511-4cc7-98df-a74254b0129b.png">

## Reference 

- [gfx/example-github-actions-with-tty: A demo repository to prepare TTY for GitHub Actions step scripts](https://github.com/gfx/example-github-actions-with-tty)
- https://github.com/actions/runner/issues/241