### PR TITLE
Bump go version to 1.18 of the go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,23 @@
 module github.com/toshimaru/nyan
 
-go 1.16
+go 1.18
 
 require (
 	github.com/alecthomas/chroma v0.10.0
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Go 1.18 is used in the release workflow, but go version of the go.mod is still 1.16.
I upgrade go version by below commands.

```shell
$ go mod edit -go=1.18
$ go mod tidy
```