### PR TITLE
build: Update `.goreleaser.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build & Test
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
-    - name: Build & Test
-      run: |
-        go build -v
-        go test ./...
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v4
-      with:
-        args: release --snapshot --skip-publish --rm-dist
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Build & Test
+        run: |
+          go build -v
+          go test ./...
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: release --clean --snapshot --skip-publish
 
-    # ref. https://github.com/gfx/example-github-actions-with-tty
-    - name: Colored Output Test
-      if: runner.os == 'Linux'
-      shell: 'script -q -e -c "bash {0}"'
-      run: go run main.go -- main.go
+      # ref. https://github.com/gfx/example-github-actions-with-tty
+      - name: Colored Output Test
+        if: runner.os == 'Linux'
+        shell: 'script -q -e -c "bash {0}"'
+        run: go run main.go -- main.go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Unshallow Fetch
-      run: git fetch --prune --unshallow
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
-    - name: Release via goreleaser
-      uses: goreleaser/goreleaser-action@v4
-      with:
-        args: release
-      env:
-        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: git fetch tags
+        run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Release via goreleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,43 +1,67 @@
-builds:
-- env:
-    - CGO_ENABLED=0
-  goos:
-    - linux
-    - darwin
-    - windows
-  ignore:
-    - goos: darwin
-      goarch: 386
-    - goos: windows
-      goarch: arm64
-  ldflags:
-    - -s -w -X github.com/toshimaru/nyan/cmd.version={{.Version}}
+before:
+  hooks:
+    - go mod tidy
 
-archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    format_overrides:
-    - goos: windows
-      format: zip
-checksum:
-  name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
+report_sizes: true
+
+metadata:
+  mod_timestamp: "{{ .CommitTimestamp }}"
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser -X main.treeState={{ .IsGitDirty }}
+
+checksum:
+  name_template: 'checksums.txt'
+
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
-    - Merge pull request
+      - merge conflict
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+  groups:
+    - title: "New Features"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 3
+    - title: "Documentation updates"
+      regexp: ^.*?doc(\([[:word:]]+\))??!?:.+$
+      order: 5
+    - title: Dependency updates
+      regexp: '^.*?(feat|fix)\(deps\)!?:.+$'
+      order: 10
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ title .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        format: zip
 
 brews:
-  - tap:
+  - repository:
       owner: toshimaru
       name: homebrew-nyan
     description: Colored cat command which supports syntax highlighting

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,3 +69,6 @@ brews:
     license: MIT
     test: |
       system "#{bin}/nyan", "-v"
+
+release:
+  name_template: "v{{ .Version }}"


### PR DESCRIPTION
Update goreleaser configuration (`.goreleaser.yml`).

ref. https://github.com/goreleaser/goreleaser/blob/4526c5b6813ade905f9658467c3a85aa25bdc9b9/.goreleaser.yaml

### Others

- ci: Set fetch-depth: 0 for release
- fix: Remove deprecated option `--rm-dist`, use `--clean` instead