### PR TITLE
Bump go from 1.20 to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Build & Test
         run: |
           go build -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           go build -v
           go test ./...
+      # It only runs on Linux because the goreleaser command is executed on Linux.
       - name: Run GoReleaser
+        if: runner.os == 'Linux'
         uses: goreleaser/goreleaser-action@v4
         with:
           args: release --clean --snapshot --skip-publish

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - run: go build
       - uses: paambaati/codeclimate-action@v5.0.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: git fetch --force --tags
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: reviewdog/action-staticcheck@v1
         with:
           fail_on_error: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/toshimaru/nyan
 
-go 1.20
+go 1.21.0
 
 require (
 	github.com/alecthomas/chroma v0.10.0


### PR DESCRIPTION
- Bump go version from 1.20 to 1.21
  - [Go 1.21 Release Notes - The Go Programming Language](https://tip.golang.org/doc/go1.21)
- Run goreleaser on Linux only