### PR TITLE
Bump go from 1.22 to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: Build & Test
         run: |
           go build -v

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - run: go build
       - uses: paambaati/codeclimate-action@v9.0.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - uses: reviewdog/action-staticcheck@v1
         with:
           fail_on_error: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/toshimaru/nyan
 
-go 1.22
+go 1.23
 
 require (
 	github.com/alecthomas/chroma v0.10.0


### PR DESCRIPTION
This pull request updates the Go version used across the project from `1.22` to `1.23`. The changes affect multiple workflow files and the `go.mod` file to ensure consistency in the build, test, and release processes.

### Go Version Update:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-R20): Updated the `go-version` in the CI workflow to `1.23` for building and testing the project.
* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L14-R14): Updated the `go-version` in the coverage workflow to `1.23` for generating code coverage reports.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L17-R17): Updated the `go-version` in the release workflow to `1.23` for the release process using `goreleaser`.
* [`.github/workflows/reviewdog.yml`](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dL13-R13): Updated the `go-version` in the reviewdog workflow to `1.23` for static analysis.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version declaration to `1.23` to align with the workflows and ensure compatibility.