### PR TITLE
Remove reviewers in `dependabot.yml`, add `CODEOWNERS` file instead.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @toshimaru

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    reviewers:
-    - toshimaru
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-    reviewers:
-    - toshimaru
+      interval: "weekly"


### PR DESCRIPTION
This pull request makes minor adjustments to repository configuration files. It adds a new code owner and updates the Dependabot configuration to remove reviewers for dependency updates.

Repository configuration changes:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1): Added `@toshimaru` as a code owner for all files.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R10): Removed `@toshimaru` as a reviewer for dependency updates and standardized the `interval` field formatting.