### PR TITLE
Bump Go to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Build & Test
         run: |
           go build -v

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - run: go build
       - uses: paambaati/codeclimate-action@v9.0.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: reviewdog/action-staticcheck@v1
         with:
           fail_on_error: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/toshimaru/nyan
 
-go 1.23
+go 1.24
 
 require (
 	github.com/alecthomas/chroma v0.10.0


### PR DESCRIPTION
## Summary
- bump Go to version 1.24
- use Go 1.24 in CI workflows

## Testing
- `go build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68647ef0b46c832b8b088d95de0768aa