### PR TITLE
Update .goreleaser.yml to v2 and adjust config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --clean --snapshot --skip-publish
+          args: release --clean --snapshot --skip=publish
       # Output tests
       - name: Normal Output Test
         run: go run main.go -- main.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # It only runs on Linux because the goreleaser command is executed on Linux.
       - name: Run GoReleaser
         if: runner.os == 'Linux'
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean --snapshot --skip-publish
       # Output tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: '1.24'
       - name: Release via goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: release
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,14 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
+
+release:
+  name_template: "v{{ .Version }}"
 
 report_sizes: true
 
@@ -56,17 +61,13 @@ archives:
   - name_template: '{{ .ProjectName }}_{{ title .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ zip ]
 
-brews:
+homebrew_casks:
   - repository:
       owner: toshimaru
       name: homebrew-nyan
     description: Colored cat command which supports syntax highlighting
     homepage: https://github.com/toshimaru/nyan
     license: MIT
-    test: |
-      system "#{bin}/nyan", "-v"
 
-release:
-  name_template: "v{{ .Version }}"


### PR DESCRIPTION
closes. #179

Fix the warnings:

```
error=unknown flag: --skip-publish
```

## Pull Request Overview

This PR upgrades the GoReleaser configuration to version 2 and aligns the GitHub Actions workflows with the new CLI and action versions.
- Upgrade `.goreleaser.yml` to v2: replace deprecated properties (`snapshot.name_template`, `format_overrides.format`, `brews`) with the new counterparts.
- Update GitHub Actions to use `goreleaser-action@v6` and adjust the skip flag syntax in CI.


### Before

```console
❯ goreleaser check
  • only version: 2 configuration files are supported, yours is version: 0, please update your configuration
  • checking                                  path=.goreleaser.yml
  • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
  • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ check failed                                     error=1 out of 1 configuration file(s) have issues
```

### After

```console
❯ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

## Related

- #179

## References

- [Deprecation notices - GoReleaser](https://goreleaser.com/deprecations/)