### PR TITLE
Code Climate to Qlty

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Coverage with CodeClimate
+name: Coverage
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ permissions:
   contents: read
   id-token: write
 jobs:
-  codeclimate-report:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +17,9 @@ jobs:
           go-version: "1.24"
       - name: Output coverage report
         run: go build && go test ./... -coverprofile coverage.out
-      - uses: qltysh/qlty-action/coverage@v1
+      # ref. https://github.com/qltysh/example-go
+      - name: Report coverage with Qlty
+        uses: qltysh/qlty-action/coverage@v1
         with:
           oidc: true
           files: coverage.out

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - run: go build
+      - name: Output coverage report
+        run: go build && go test ./... -coverprofile c.out
       - uses: paambaati/codeclimate-action@v9.0.0
         env:
           CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,8 +2,11 @@ name: Coverage with CodeClimate
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
+permissions:
+  contents: read
+  id-token: write
 jobs:
   codeclimate-report:
     runs-on: ubuntu-latest
@@ -11,12 +14,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
       - name: Output coverage report
-        run: go build && go test ./... -coverprofile c.out
-      - uses: paambaati/codeclimate-action@v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: f4c78effd3a10a5a45239e6886b35f42475467ad53f09a01002feeb04eb92d5b
+        run: go build && go test ./... -coverprofile coverage.out
+      - uses: qltysh/qlty-action/coverage@v1
         with:
-          coverageCommand: go test ./... -coverprofile c.out
-          prefix: github.com/toshimaru/nyan
+          oidc: true
+          files: coverage.out
+          strip-prefix: github.com/toshimaru/nyan


### PR DESCRIPTION
This pull request updates the `.github/workflows/coverage.yml` file to transition from CodeClimate to Qlty for coverage reporting. It includes changes to the workflow name, job naming, permissions setup, and the coverage reporting process.

## References

- [example-go/.github/workflows/main.yml at main · qltysh/example-go](https://github.com/qltysh/example-go/blob/main/.github/workflows/main.yml)
- [qltysh/qlty: 💎 Code quality CLI for universal linting, auto-formatting, security scanning, and maintainability](https://github.com/qltysh/qlty)
- [Code Climate Qualityの後継はQlty](https://invokable.net/article/qlty)

### Transition to Qlty for coverage reporting:
* Updated workflow name from "Coverage with CodeClimate" to "Coverage with Qlty."
* Changed job name from `codeclimate-report` to `coverage` and updated the steps to use Qlty's coverage action instead of CodeClimate's.
* Added `permissions` section to enable `contents: read` and `id-token: write` for the workflow.
* Modified the coverage reporting process to use `go build && go test ./... -coverprofile coverage.out` and integrated Qlty's `qlty-action/coverage` with OIDC authentication and updated file handling.