### PR TITLE
chore: Add Qlty badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Release](https://img.shields.io/github/release/toshimaru/nyan.svg)](https://github.com/toshimaru/nyan/releases/latest)
 ![Go Build & Test](https://github.com/toshimaru/nyan/workflows/Go%20Build%20&%20Test/badge.svg)
 ![Release with goreleaser](https://github.com/toshimaru/nyan/workflows/Release%20with%20goreleaser/badge.svg)
-[![Maintainability](https://api.codeclimate.com/v1/badges/f5063da42c2e2b00e625/maintainability)](https://codeclimate.com/github/toshimaru/nyan/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/f5063da42c2e2b00e625/test_coverage)](https://codeclimate.com/github/toshimaru/nyan/test_coverage)
+[![Maintainability](https://qlty.sh/gh/toshimaru/projects/nyan/maintainability.svg)](https://qlty.sh/gh/toshimaru/projects/nyan)
+[![Code Coverage](https://qlty.sh/gh/toshimaru/projects/nyan/coverage.svg)](https://qlty.sh/gh/toshimaru/projects/nyan)
 
 # nyan
 


### PR DESCRIPTION
This pull request updates the badges in the `README.md` file to use a new service for maintainability and code coverage metrics.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R5): Replaced Code Climate badges with Quality (qlty.sh) badges for maintainability and code coverage.