### PR TITLE
 chore: Simplify release workflow name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release with goreleaser
+name: Release
 on:
   push:
     tags:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 Toshimaru
+Copyright (c) 2019-2025 Toshimaru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Release](https://img.shields.io/github/release/toshimaru/nyan.svg)](https://github.com/toshimaru/nyan/releases/latest)
-![Go Build & Test](https://github.com/toshimaru/nyan/workflows/Go%20Build%20&%20Test/badge.svg)
-![Release with goreleaser](https://github.com/toshimaru/nyan/workflows/Release%20with%20goreleaser/badge.svg)
+[![release](https://img.shields.io/github/release/toshimaru/nyan.svg)](https://github.com/toshimaru/nyan/releases/latest)
+[![Go Build & Test](https://github.com/toshimaru/nyan/actions/workflows/ci.yml/badge.svg)](https://github.com/toshimaru/nyan/actions/workflows/ci.yml)
+[![Release](https://github.com/toshimaru/nyan/actions/workflows/release.yml/badge.svg)](https://github.com/toshimaru/nyan/actions/workflows/release.yml)
 [![Maintainability](https://qlty.sh/gh/toshimaru/projects/nyan/maintainability.svg)](https://qlty.sh/gh/toshimaru/projects/nyan)
 [![Code Coverage](https://qlty.sh/gh/toshimaru/projects/nyan/coverage.svg)](https://qlty.sh/gh/toshimaru/projects/nyan)
 


### PR DESCRIPTION
This pull request includes updates to the project metadata and workflow configuration. Key changes involve renaming a GitHub Actions workflow, updating copyright years in the `LICENSE` file, and modifying badges in the `README.md` for better alignment with current workflows.

### Workflow Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L1-R1): Renamed the workflow from "Release with goreleaser" to "Release" for simplicity.

### Metadata Updates:
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright years from 2019-2022 to 2019-2025.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3): Adjusted badge links to reflect changes in workflow names and paths, ensuring they point to the correct GitHub Actions workflows.