### PR TITLE
docs: Update README.md and command description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Normal Output Test
         run: go run main.go -- main.go
       # ref. https://github.com/gfx/example-github-actions-with-tty
-      - name: Colored Output Test
+      - name: Colorized Output Test
         if: runner.os == 'Linux'
         shell: 'script -q -e -c "bash {0}"'
         run: go run main.go -- main.go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
       - -s -w -X github.com/toshimaru/nyan/cmd.version={{.Version}}
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 changelog:
   sort: asc
@@ -58,16 +58,15 @@ changelog:
       order: 99
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ title .Os }}_{{ .Arch }}'
+  - name_template: "{{ .ProjectName }}_{{ title .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        formats: [ zip ]
+        formats: [zip]
 
 homebrew_casks:
   - repository:
       owner: toshimaru
       name: homebrew-nyan
-    description: Colored cat command which supports syntax highlighting
+    description: Colorizing `cat` command with syntax highlighting
     homepage: https://github.com/toshimaru/nyan
     license: MIT
-

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ $ go install github.com/toshimaru/nyan@latest
 $ nyan FILE
 ```
 
+![nyan command sample](https://github.com/user-attachments/assets/ba6a3248-3f8f-49ab-b1b1-1e6c4a084a99)
+
 ### Available Options
 
 | Option | Description |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ Colorizing `cat` command with syntax highlighting.
 ### Homebrew
 
 ```console
-$ brew install toshimaru/nyan/nyan
+$ brew install nyan
 ```
+
+<details>
+<summary>Homebrew Tap</summary>
+
+```console
+$ brew install --cask toshimaru/nyan/nyan
+```
+
+</details>
 
 ### go get
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # nyan
 
-Colored `cat` command which supports syntax highlighting.
+Colorizing `cat` command with syntax highlighting.
 
 ![OG image for nyan command](https://repository-images.githubusercontent.com/195893425/0a7e7dfc-3a80-49d5-8193-5482fe2e7848)
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,24 @@ Colorizing `cat` command with syntax highlighting.
 $ brew install nyan
 ```
 
+> [!NOTE]
+> As of v1.2.0, `nyan` has been merged into [homebrew-core](https://github.com/Homebrew/homebrew-core). :tada:
+>
+> If you see:
+>
+> ```
+> Error: nyan was installed from the toshimaru/nyan tap
+> ```
+>
+> simply reinstall from the core tap:
+>
+> ```console
+> $ brew uninstall nyan
+> $ brew install nyan
+> ```
+
 <details>
-<summary>Homebrew Tap</summary>
+<summary><strong>Install via Homebrew Tap</strong></summary>
 
 ```console
 $ brew install --cask toshimaru/nyan/nyan

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,8 +28,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "nyan [flags] [FILE]...",
-	Short: "Colored cat command.",
-	Long:  "Colored cat command which supports syntax highlighting.",
+	Short: "Colorizing cat command.",
+	Long:  "Colorizing `cat` command with syntax highlighting.",
 	Example: `$ nyan FILE
 $ nyan FILE1 FILE2 FILE3
 $ nyan -t solarized-dark FILE


### PR DESCRIPTION
closes #44 

## Reference

- https://github.com/Homebrew/homebrew-core/pull/230045

## Changes

- Update README.md
- docs: Use official formula instead of brew tap
- docs: Add command sample image
- docs: nyan is now added homebrew-core
- chore: Update descriptions

## Image

<img width="1819" height="817" alt="Colorizing `cat` command with nyan" src="https://github.com/user-attachments/assets/ba6a3248-3f8f-49ab-b1b1-1e6c4a084a99" />

----

This pull request includes updates to improve consistency in terminology, enhance documentation, and standardize configuration files. The most significant changes involve rephrasing descriptions to use "colorizing" instead of "colored," updating the `README.md` with new installation notes, and standardizing string formatting in configuration files.

### Terminology Updates:
* Updated descriptions in `README.md` and `cmd/root.go` to replace "Colored `cat` command" with "Colorizing `cat` command" for consistency and clarity. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R45); `cmd/root.go`: [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL31-R32)

### Documentation Enhancements:
* Expanded the `README.md` with instructions for installing `nyan` via Homebrew Core, including a note about the migration from a tap to the core repository. Added a collapsible section for alternative installation via the tap.
* Added a sample image of the `nyan` command output to the `README.md` for better visualization.

### Configuration Standardization:
* Standardized string formatting in `.goreleaser.yml` by replacing single quotes with double quotes for consistency. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L33-R33) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L61-R61)
* Updated the description of the Homebrew cask in `.goreleaser.yml` to align with the new terminology.

### Minor Workflow Adjustment:
* Renamed the "Colored Output Test" to "Colorized Output Test" in the GitHub Actions workflow file for consistency with the updated terminology. (`.github/workflows/ci.yml`: [.github/workflows/ci.ymlL35-R35](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL35-R35))