### PR TITLE
chore: Disabled completion command 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,9 +34,10 @@ var rootCmd = &cobra.Command{
 $ nyan FILE1 FILE2 FILE3
 $ nyan -t solarized-dark FILE
 $ nyan -l go FILE`,
-	RunE:          cmdMain,
-	SilenceErrors: true,
-	SilenceUsage:  false,
+	RunE:              cmdMain,
+	SilenceErrors:     true,
+	SilenceUsage:      false,
+	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 }
 
 func init() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -142,6 +142,18 @@ func TestMultipleFilesWithInvalidFileError(t *testing.T) {
 	assert.Contains(t, e.String(), invalidFileErrorMsg())
 }
 
+func TestCompletionDisabled(t *testing.T) {
+	var o, e bytes.Buffer
+	rootCmd.SetArgs([]string{"completion"})
+	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
+	err := rootCmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, e.String(), "Error: open completion:")
+	assert.Empty(t, o.String())
+}
+
 func testThemes(t *testing.T) {
 	var o, e bytes.Buffer
 	isTerminalFunc = func(fd uintptr) bool { return true }


### PR DESCRIPTION
Disabled completion command provided by Cobra

ref(ja). [cobra で `helpコマンド` を非表示にする](https://enuesaa.dev/posts/go-cobra-disable-help-command)

----

This pull request introduces a change to disable the default shell completion command in the CLI tool and adds a corresponding test to ensure this behavior is enforced.

Shell completion command disabled:

* Set `CompletionOptions.DisableDefaultCmd` to `true` in the `rootCmd` configuration in `cmd/root.go`, preventing the default Cobra shell completion command from being available.

Testing:

* Added `TestCompletionDisabled` in `cmd/root_test.go` to verify that running the `completion` command returns an error and does not produce any output, confirming the completion command is disabled.