### PR TITLE
Replace bytes.Compare with bytes.Equal in Flush

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -205,7 +205,7 @@ func (w *numberWriter) Write(p []byte) (n int, err error) {
 
 func (w *numberWriter) Flush() error {
 	terminalReset := []byte("\u001B[0m")
-	if bytes.Compare(w.buf, terminalReset) == 0 {
+	if bytes.Equal(w.buf, terminalReset) {
 		// In almost all cases, a control code is passed last to reset the terminal's color code.
 		// This is not a printable character and should not be counted as a line, so it is output as is without a line number.
 		_, err := fmt.Fprintf(w.w, "%s", string(w.buf))


### PR DESCRIPTION
Refactored the comparison in numberWriter.Flush to use bytes.Equal instead of bytes.Compare for clarity and correctness when checking for terminal reset sequences.

ref https://staticcheck.dev/docs/checks/#S1004