### PR TITLE
Update Go toolchain version from 1.24 to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Build & Test
         run: |
           go build -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Build & Test
         run: |
           go build -v

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Output coverage report
         run: go build && go test ./... -coverprofile coverage.out
       # ref. https://github.com/qltysh/example-go

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Output coverage report
         run: go build && go test ./... -coverprofile coverage.out
       # ref. https://github.com/qltysh/example-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - uses: reviewdog/action-staticcheck@v1
         with:
           fail_on_error: true

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: reviewdog/action-staticcheck@v1
         with:
           fail_on_error: true

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/toshimaru/nyan
 
 go 1.24
 
+toolchain go1.25.0
+
 require (
 	github.com/alecthomas/chroma/v2 v2.18.0
 	github.com/mattn/go-colorable v0.1.14


### PR DESCRIPTION
This pull request updates the Go toolchain configuration and CI workflows to ensure consistency with the version specified in `go.mod`. The main change is switching all GitHub Actions workflows to use the Go version defined in `go.mod` rather than hardcoding a specific version, and explicitly specifying the toolchain version in `go.mod`.

**Go toolchain and workflow configuration:**

* Added `toolchain go1.25.0` to `go.mod` to explicitly specify the required Go toolchain version.

**Continuous Integration workflows:**

* Updated `.github/workflows/ci.yml`, `.github/workflows/coverage.yml`, `.github/workflows/release.yml`, and `.github/workflows/reviewdog.yml` to use `go-version-file: go.mod` in the `actions/setup-go` step, ensuring all workflows use the Go version declared in `go.mod`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-R20) [[2]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L17-R17) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L17-R17) [[4]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dL13-R13)