### PR TITLE
Update`.goreleaser.yml` settings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,16 +59,16 @@ changelog:
       - Merge branch
   groups:
     - title: "New Features"
-      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      regexp: '^.*?feat(\(.+\))?!?:.+$'
       order: 10
     - title: "Security updates"
-      regexp: '^.*?sec(\(.+\))??!?:.+$'
+      regexp: '^.*?sec(\(.+\))?!?:.+$'
       order: 15
     - title: "Bug fixes"
-      regexp: '^.*?(fix|refactor)(\(.+\))??!?:.+$'
+      regexp: '^.*?(fix|refactor)(\(.+\))?!?:.+$'
       order: 20
     - title: "Documentation updates"
-      regexp: ^.*?docs?(\(.+\))??!?:.+$
+      regexp: ^.*?docs?(\(.+\))?!?:.+$
       order: 40
     - title: Dependency updates
       regexp: '^.*?(\w*\(deps?\)|deps?)!?:.+$'


### PR DESCRIPTION
This pull request updates the `.goreleaser.yml` configuration to enhance release metadata, expand build target support, and improve changelog formatting and grouping. The changes make releases more informative and accessible, support additional architectures, and provide clearer changelog sections.

**Release metadata and formatting:**
* Added a release footer with a link to the full changelog between tags for better traceability.
* Introduced `mod_timestamp` metadata to releases and builds for improved reproducibility and tracking. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R12-R19) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R30-R53)

**Build target and flags improvements:**
* Expanded supported `goarch` targets to include `arm` and `riscv64`, set `goarm` to "7", and added build flags like `-trimpath` for cleaner binaries.
* Added a `universal_binaries` section to control binary replacement behavior.

**Changelog formatting and grouping:**
* Updated changelog entry format to include SHA, message, and author username, and refined group regexes and ordering for more accurate and organized changelog sections. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R30-R53) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L46-R75)

## Reference

- https://github.com/goreleaser/goreleaser/blob/7de292b43ab3a54ca5c013af14b6f4bb31269042/.goreleaser.yaml