### PR TITLE
Fix release notes URL in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ snapshot:
 release:
   name_template: "v{{ .Version }}"
   footer: |
-    **Full Changelog**: https://github.com/goreleaser/goreleaser/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/toshimaru/nyan/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 report_sizes: true
 


### PR DESCRIPTION
follows #210 

Update changelog URL from goreleaser/goreleaser to toshimaru/nyan to correctly point to this repository's releases.

🤖 Generated with [Claude Code](https://claude.ai/code)