### PR TITLE
deps: Bump Go toolchain version from 1.25.5 to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/toshimaru/nyan
 
 go 1.24
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/alecthomas/chroma/v2 v2.22.0


### PR DESCRIPTION
## Summary

- Bumps `toolchain go1.25.5` → `toolchain go1.26.2` in `go.mod`
- The `go 1.24` floor directive is unchanged
- All GitHub Actions workflows use `go-version-file: go.mod` and pick up the new toolchain automatically

## Test plan

- [x] `go build -v ./...` passes locally
- [x] `go test ./...` passes locally (all 3 packages)
- [x] CI passes on Ubuntu, macOS, and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)